### PR TITLE
MULTIARCH-3441: Enable builds for s390x

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,6 +12,7 @@ builds:
     goarch:
       - amd64
       - ppc64le
+      - s390x
     env:
       - CGO_ENABLED=1
     flags:

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ ARG DNF_LIST="\
 
 #################################################################################
 # Build UBI8 Builder with multi-arch support
+# Link gcc to /usr/bin/s390x-linux-gnu-gcc as go requires it on s390x
 RUN set -ex \
      && ARCH=$(arch | sed 's|x86_64|amd64|g')                                   \
      && dnf install -y --nodocs --setopt=install_weak_deps=false ${DNF_LIST}    \
@@ -28,7 +29,8 @@ RUN set -ex \
      && curl -sL https://golang.org/dl/${GO_VERSION}.linux-${ARCH}.tar.gz       \
         | tar xzvf - --directory /usr/local/                                    \
      && /usr/local/go/bin/go version                                            \
-     && ln -f /usr/local/go/bin/go /usr/bin/go
+     && ln -f /usr/local/go/bin/go /usr/bin/go                                  \
+     && ln /usr/bin/gcc /usr/bin/s390x-linux-gnu-gcc
 
 WORKDIR /build
 ENTRYPOINT ["make"]

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,11 @@ cross-build-linux-ppc64le:
 	+@GOOS=linux GOARCH=ppc64le $(MAKE) "$(GO_BUILD_FLAGS)" --no-print-directory build GO_BUILD_BINDIR=$(GO_BUILD_BINDIR)/linux-ppc64le
 .PHONY: cross-build-linux-ppc64le
 
-cross-build: cross-build-linux-amd64 cross-build-linux-ppc64le
+cross-build-linux-s390x:
+	+@GOOS=linux GOARCH=s390x $(MAKE) "$(GO_BUILD_FLAGS)" --no-print-directory build GO_BUILD_BINDIR=$(GO_BUILD_BINDIR)/linux-s390x
+.PHONY: cross-build-linux-s390x
+
+cross-build: cross-build-linux-amd64 cross-build-linux-ppc64le cross-build-linux-s390x
 .PHONY: cross-build
 
 hack-build: clean
@@ -75,12 +79,12 @@ publish-catalog:
 	@cd test/operator && make
 .PHONY: publish-catalog
 
-format: 
+format:
 	$(GO) fmt ./pkg/...
 	$(GO) fmt ./cmd/...
 .PHONY: format
 
-vet: 
-	$(GO) vet $(GO_BUILD_FLAGS) ./pkg/... 
-	$(GO) vet $(GO_BUILD_FLAGS) ./cmd/...  
+vet:
+	$(GO) vet $(GO_BUILD_FLAGS) ./pkg/...
+	$(GO) vet $(GO_BUILD_FLAGS) ./cmd/...
 .PHONY: vet


### PR DESCRIPTION
- Update the .goreleaser.yaml to include s390x
- Update the cross build for s390x
- Link gcc to s390x-linux-gnu-gcc binary

On s390x go compiler seems to expect the gcc binary at s390x-linux-gnu-gcc binary. However on rhel it is not installed there.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules