### PR TITLE
MULTIARCH-3441: Enable builds for s390x (#1)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,6 +12,7 @@ builds:
     goarch:
       - amd64
       - ppc64le
+      - s390x
     env:
       - CGO_ENABLED=1
     flags:

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,13 @@ RUN set -ex \
      && /usr/local/go/bin/go version                                            \
      && ln -f /usr/local/go/bin/go /usr/bin/go
 
+#################################################################################
+# Link gcc to /usr/bin/s390x-linux-gnu-gcc as go requires it on s390x
+RUN ARCH=$(arch | sed 's|x86_64|amd64|g')                                       \
+     && [ "${ARCH}" == "s390x" ]                                                \
+     && ln /usr/bin/gcc /usr/bin/s390x-linux-gnu-gcc                            \
+     || echo "Not running on s390x, skip linking gcc binary"
+
 WORKDIR /build
 ENTRYPOINT ["make"]
 CMD []

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,11 @@ cross-build-linux-ppc64le:
 	+@GOOS=linux GOARCH=ppc64le $(MAKE) "$(GO_BUILD_FLAGS)" --no-print-directory build GO_BUILD_BINDIR=$(GO_BUILD_BINDIR)/linux-ppc64le
 .PHONY: cross-build-linux-ppc64le
 
-cross-build: cross-build-linux-amd64 cross-build-linux-ppc64le
+cross-build-linux-s390x:
+	+@GOOS=linux GOARCH=s390x $(MAKE) "$(GO_BUILD_FLAGS)" --no-print-directory build GO_BUILD_BINDIR=$(GO_BUILD_BINDIR)/linux-s390x
+.PHONY: cross-build-linux-s390x
+
+cross-build: cross-build-linux-amd64 cross-build-linux-ppc64le cross-build-linux-s390x
 .PHONY: cross-build
 
 hack-build: clean
@@ -75,12 +79,12 @@ publish-catalog:
 	@cd test/operator && make
 .PHONY: publish-catalog
 
-format: 
+format:
 	$(GO) fmt ./pkg/...
 	$(GO) fmt ./cmd/...
 .PHONY: format
 
-vet: 
-	$(GO) vet $(GO_BUILD_FLAGS) ./pkg/... 
-	$(GO) vet $(GO_BUILD_FLAGS) ./cmd/...  
+vet:
+	$(GO) vet $(GO_BUILD_FLAGS) ./pkg/...
+	$(GO) vet $(GO_BUILD_FLAGS) ./cmd/...
 .PHONY: vet


### PR DESCRIPTION
- Update the .goreleaser.yaml to include s390x
- Update the cross build for s390x
- Link gcc to s390x-linux-gnu-gcc binary

On s390x go compiler seems to expect the gcc binary at s390x-linux-gnu-gcc binary. However on rhel it is not installed there.